### PR TITLE
Add admin mode: teacher login and protected signup/unregister

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +21,15 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from JSON file
+teachers_file = Path(__file__).parent / "teachers.json"
+with open(teachers_file) as f:
+    teachers_data = json.load(f)
+teachers = {t["username"]: t for t in teachers_data["teachers"]}
+
+# In-memory session store: token -> teacher username
+sessions: dict[str, str] = {}
 
 # In-memory activity database
 activities = {
@@ -83,14 +95,46 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+@app.post("/auth/login")
+def login(credentials: LoginRequest):
+    """Log in as a teacher and receive a session token"""
+    teacher = teachers.get(credentials.username)
+    if not teacher or teacher["password"] != credentials.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    token = secrets.token_hex(32)
+    sessions[token] = credentials.username
+    return {"token": token, "name": teacher["name"]}
+
+
+@app.post("/auth/logout")
+def logout(authorization: str = Header(default="")):
+    """Log out and invalidate the session token"""
+    token = authorization.removeprefix("Bearer ").strip()
+    sessions.pop(token, None)
+    return {"message": "Logged out"}
+
+
+def require_teacher(authorization: str):
+    """Helper to validate a session token from the Authorization header"""
+    token = authorization.removeprefix("Bearer ").strip()
+    if token not in sessions:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, authorization: str = Header(default="")):
+    """Sign up a student for an activity (requires teacher login)"""
+    require_teacher(authorization)
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +155,9 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, authorization: str = Header(default="")):
+    """Unregister a student from an activity (requires teacher login)"""
+    require_teacher(authorization)
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,102 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const teacherNameSpan = document.getElementById("teacher-name");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+  const loginError = document.getElementById("login-error");
+  const signupContainer = document.getElementById("signup-container");
+
+  // Session state
+  let sessionToken = sessionStorage.getItem("sessionToken") || null;
+  let teacherName = sessionStorage.getItem("teacherName") || null;
+
+  function isLoggedIn() {
+    return !!sessionToken;
+  }
+
+  function updateAuthUI() {
+    if (isLoggedIn()) {
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      teacherNameSpan.textContent = `👤 ${teacherName}`;
+      teacherNameSpan.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+    } else {
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      teacherNameSpan.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+    }
+    // Refresh to show/hide delete buttons
+    fetchActivities();
+  }
+
+  // Login modal open/close
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    loginError.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  cancelLoginBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) loginModal.classList.add("hidden");
+  });
+
+  // Login form submit
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        sessionToken = result.token;
+        teacherName = result.name;
+        sessionStorage.setItem("sessionToken", sessionToken);
+        sessionStorage.setItem("teacherName", teacherName);
+        loginModal.classList.add("hidden");
+        updateAuthUI();
+      } else {
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginError.textContent = "Login failed. Please try again.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Logout
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${sessionToken}` },
+      });
+    } finally {
+      sessionToken = null;
+      teacherName = null;
+      sessionStorage.removeItem("sessionToken");
+      sessionStorage.removeItem("teacherName");
+      updateAuthUI();
+    }
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +126,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isLoggedIn()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -80,6 +180,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: { Authorization: `Bearer ${sessionToken}` },
         }
       );
 
@@ -124,6 +225,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: `Bearer ${sessionToken}` },
         }
       );
 
@@ -156,5 +258,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  updateAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,34 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-area">
+        <span id="teacher-name" class="hidden"></span>
+        <button id="login-btn">Login</button>
+        <button id="logout-btn" class="hidden">Logout</button>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="cancel-login-btn">Cancel</button>
+          </div>
+          <div id="login-error" class="hidden error"></div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -21,7 +48,7 @@
         </div>
       </section>
 
-      <section id="signup-container">
+      <section id="signup-container" class="hidden">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,11 +22,82 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
-header h1 {
-  margin-bottom: 10px;
+#auth-area {
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
+
+#teacher-name {
+  font-size: 14px;
+  color: #c5cae9;
+}
+
+#login-btn,
+#logout-btn {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 6px 14px;
+  font-size: 14px;
+}
+
+#login-btn:hover,
+#logout-btn:hover {
+  background-color: rgba(255, 255, 255, 0.35);
+}
+
+/* Login modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 380px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.modal-actions button[type="button"] {
+  background-color: #9e9e9e;
+}
+
+.modal-actions button[type="button"]:hover {
+  background-color: #757575;
+}
+
+
 
 main {
   display: flex;

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    { "username": "msmith", "password": "Mergington2026!", "name": "Mr. Smith" },
+    { "username": "mjohnson", "password": "Mergington2026!", "name": "Ms. Johnson" }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #5

Adds a teacher login system so that only authenticated teachers can register or unregister students. Students can still view all activities and current participants without logging in.

## Changes

### Backend (`src/app.py`)
- Loads teacher credentials from `src/teachers.json` on startup
- `POST /auth/login` — validates username/password, returns a session token
- `POST /auth/logout` — invalidates the session token
- `POST /activities/{name}/signup` and `DELETE /activities/{name}/unregister` now require a valid `Authorization: Bearer <token>` header (returns 401 otherwise)

### Credentials (`src/teachers.json`)
- New file storing teacher usernames, passwords, and display names
- Default accounts: `msmith` and `mjohnson` (password: `Mergington2026!`)

### Frontend (`src/static/index.html`)
- Login button in the top-right of the header
- Login modal dialog with username/password fields
- Signup section hidden by default; only shown when a teacher is logged in

### Frontend (`src/static/app.js`)
- Session token stored in `sessionStorage`
- Login/logout events wired to modal and header buttons
- Unregister ❌ buttons only rendered when logged in
- `Authorization` header sent on all signup/unregister API requests

### Styles (`src/static/styles.css`)
- Header auth area positioned top-right
- Login/logout button styles
- Modal overlay and dialog styles